### PR TITLE
Reformat cdp dissector

### DIFF
--- a/LanMap Filter/LanMap Filter.cpp
+++ b/LanMap Filter/LanMap Filter.cpp
@@ -805,7 +805,7 @@ int saveHost()
 
 int LoadConfig()
 {
-	LogfileOutput("Starting Switchy McPortface\n", 0);
+	printf("Starting Switchy McPortface version %s\n", VERSION_STRING);
 
 	char * fileName = "config.ini";
 	//FILE *pFile = fopen_s(fileName, "r");

--- a/LanMap Filter/dissectors.cpp
+++ b/LanMap Filter/dissectors.cpp
@@ -42,7 +42,7 @@ Dissectors::IndexValue Dissectors::cdp_tlv_type[22] =
 	{ 0, NULL }
 };
 
-int Dissectors::GetDataCDP(const u_char* packetData, int dataLength) 
+int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 {
 	printf("\n\tDestination MAC address:\t %02x:%02x:%02x:%02x:%02x:%02x", packetData[0], packetData[1], packetData[2], packetData[3], packetData[4], packetData[5]);
 	printf("\n\tSource MAC address:\t\t %02x:%02x:%02x:%02x:%02x:%02x", packetData[6], packetData[7], packetData[8], packetData[9], packetData[10], packetData[11]);
@@ -61,22 +61,23 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 		//length = length & mask;
 		count += 4;
 		length -= 4;
-		
+
 		printf("\n\t%s", cdp_tlv_type[type].value);
+
+		for (UINT16 x = 0; x < length; x++)
+		{
+			value[x] = packetData[count];
+			count++;
+		}
+		printf("%s", value);//, count - length);
+		break;
+
 		switch (type)
 		{
 			case 0x01: //Device ID
 			{
 				memcpy(&Poststring::systemswName, packetData + count, length);
 				Poststring::slsystemswName = strlen(Poststring::systemswName);
-
-				for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
-				printf("%s", value);//, count - length);
-				break;
 			}
 			case 0x02: //Address
 			{
@@ -122,65 +123,23 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 			}
 			case 0x04: //Capabilities
 			{
-				for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
-				printf("%s", value);//, count - length);
-				break;
 			}
 			case 0x05: //Version string, can be quite long
 			{
-				for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
-				printf("%s", value);//, count - length);
-				break;
 			}
 			case 0x06: //Platform
 			{
 				memcpy(&Poststring::systemswMAC, packetData + count, length);
 				Poststring::slsystemswMAC = strlen(Poststring::systemswMAC);
-				for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
-				printf("%s", value);//, count - length);
-				break;
 			}
 			case 0x07: //Prefixes
 			{
-				for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
-				printf("%s", value);//, count - length);
-				break;
 			}
 			case 0x08: //Protocol-hello option
 			{
-				for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
-				printf("%s", value);//, count - length);
-				break;
 			}
 			case 0x09: //VTP Management domain
 			{
-				for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
-				printf("%s", value);//, count - length);
-				break;
 			}
 			case 0x0a: //Native VLAN ID
 			{
@@ -197,212 +156,66 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 			}
 			case 0x0b: //Duplex
 			{
-				for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
-				printf("%s", value);//, count - length);
-				break;
 			}
 			case 0x0c:
 			{
-				for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
-				printf("%s", value);//, count - length);
-				break;
 			}
 			case 0x0d:
 			{
-				for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
-				printf("%s", value);//, count - length);
-				break;
 			}
 			case 0x0e: //ATA - 186 VoIP VLAN request
 			{
-				for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
-				printf("%s", value);//, count - length);
-				break;
 			}
 			case 0x0f: //ATA-186 VoIP VLAN assignment
 			{
-				for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
-				printf("%s", value);//, count - length);
-				break;
 			}
 			case 0x10: //Power Consumption
 			{
-				for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
-				printf("%s", value);//, count - length);
-				break;
 			}
 			case 0x11: //MTU
 			{
-				for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
-				printf("%s", value);//, count - length);
-				break;
 			}
 			case 0x12: //AVVID Trust bitmap
 			{
-				for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
-				printf("%s", value);//, count - length);
-				break;
 			}
 			case 0x13: //AVVID Untrusted Ports CoS
 			{
-				for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
-				printf("%s", value);//, count - length);
-				break;
 			}
 			case 0x14: //System Name
 			{
-				for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
-				printf("%s", value);//, count - length);
-				break;
 			}
 			case 0x15: //System Object ID?
 			{
-				for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
-				printf("%s", value);//, count - length);
-				break;
 			}
 			case 0x16: //Management Address
 			{
-				for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
-				printf("%s", value);//, count - length);
-				break;
 			}
 			case 0x17: //Location - physical location?
-			{	
-				for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
-				printf("%s", value);//, count - length);
-				break;
+			{
 			}
 			case 0x18: //Unknown
 			{
-				for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
-				printf("%s", value);//, count - length);
-				break;
 			}
 			case 0x19:
 			{
-				for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
-				printf("%s", value);//, count - length);
-				break;
 			}
 			case 0x1a: //Power available
 			{
-				for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
-				printf("%s", value);//, count - length);
-				break;
 			}
 			case 0x1b:
 			{
-				for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
-				printf("%s", value);//, count - length);
-				break;
 			}
 			case 0x1c:
-			{for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
-				printf("%s", value);//, count - length);
-				break;
+			{
 			}
 			case 0x1d: //Energywise
 			{
-				for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
-				printf("%s", value);//, count - length);
-				break;
 			}
 			case 0x1e:
 			{
-				for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
-				printf("%s", value);//, count - length);
-				break;
 			}
 			case 0x1f: //Spare POE
 			{
-				for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
-				printf("%s", value);//, count - length);
-				break;
 			}
 			default:
 			{

--- a/LanMap Filter/dissectors.cpp
+++ b/LanMap Filter/dissectors.cpp
@@ -46,8 +46,8 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 {
 	printf("\n\tDestination MAC address:\t %02x:%02x:%02x:%02x:%02x:%02x", packetData[0], packetData[1], packetData[2], packetData[3], packetData[4], packetData[5]);
 	printf("\n\tSource MAC address:\t\t %02x:%02x:%02x:%02x:%02x:%02x", packetData[6], packetData[7], packetData[8], packetData[9], packetData[10], packetData[11]);
-	printf("\n\tLength:\t\t %i", (packetData[12] << 8 | packetData[13]));
-	printf("\n\tCisco Discovery Protcol version %i", packetData[22]);
+	printf("\n\tLength:\t\t\t\t %i", (packetData[12] << 8 | packetData[13]));
+	printf("\n\tCisco Discovery Protocol Version %i", packetData[22]);
 	//printf("\n\tTTL:%i", packetData[23]);
 
 	unsigned int count = 26;
@@ -62,161 +62,95 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 		count += 4;
 		length -= 4;
 
-		printf("\n\t%s", cdp_tlv_type[type].value);
-
 		for (UINT16 x = 0; x < length; x++)
 		{
 			value[x] = packetData[count];
 			count++;
 		}
-		printf("%s", value);//, count - length);
-		break;
+
+		printf("\n\t%s: %s", cdp_tlv_type[type].value, value);
 
 		switch (type)
 		{
 			case 0x01: //Device ID
 			{
-				memcpy(&Poststring::systemswName, packetData + count, length);
+				memcpy(&Poststring::systemswName, packetData + count-length, length);
 				Poststring::slsystemswName = strlen(Poststring::systemswName);
+				break;
 			}
 			case 0x02: //Address
 			{
-				long numberOfAddresses = (packetData[count] << 24 | packetData[count] << 16 | packetData[count + 2] << 8 | packetData[count + 3]);
-				count += 4;
-				length -= 4;
-				for (UINT16 x = 0; x < numberOfAddresses; x++)
+				long numberOfAddresses = (value[0] << 24 | value[1] << 16 | value[2] << 8 | value[3]);
+				int tempCount = 4;
+				for (UINT16 addressIndex = 0; addressIndex < numberOfAddresses; addressIndex++)
 				{
-					//Protocol type
-					//Protocol length
-					count += 2;
+					//Protocol type and length
+					tempCount += 2;
 
 					//This is an IP address
-					if (packetData[count] == 0xcc)
+					if (value[tempCount] == 0xcc)
 					{
 						printf("IP Address: ");
-						count++;
+						tempCount++;
 
 						//This is how long it is
-						int addressLength = (packetData[count] << 8 | packetData[count + 1]);
-						count += 2;
+						int addressLength = (value[tempCount] << 8 | value[tempCount + 1]);
+						tempCount += 2;
 
-
-						sprintf_s(Poststring::systemswIP, "%i.%i.%i.%i", packetData[count], packetData[count + 1], packetData[count + 2], packetData[count + 3]);
+						sprintf_s(Poststring::systemswIP, "%i.%i.%i.%i", value[tempCount], value[tempCount + 1], value[tempCount + 2], value[tempCount + 3]);
 						printf(Poststring::systemswIP);
 						Poststring::slsystemswIP = strlen(Poststring::systemswIP);
-						count += addressLength;
+						tempCount += addressLength;
 					}
 				}
 				break;
 			}
 			case 0x03: //Port ID
 			{
-				memcpy(&Poststring::systemswitchport, packetData + count, length);
+				memcpy(&Poststring::systemswitchport, value, length);
 				Poststring::slsystemswitchport = strlen(Poststring::systemswitchport);
-
-				for (UINT16 x = 0; x < length; x++)
-				{
-					value[x] = packetData[count];
-					count++;
-				}
 				break;
 			}
-			case 0x04: //Capabilities
+			case 0x04: break; //Capabilities
+			case 0x05: break; //Version string, can be quite long 
+			case 0x06: break; //Platform
 			{
-			}
-			case 0x05: //Version string, can be quite long
-			{
-			}
-			case 0x06: //Platform
-			{
-				memcpy(&Poststring::systemswMAC, packetData + count, length);
+				memcpy(&Poststring::systemswMAC, value, length);
 				Poststring::slsystemswMAC = strlen(Poststring::systemswMAC);
+				break;
 			}
-			case 0x07: //Prefixes
+			case 0x07: break; //Prefixes
+			case 0x08: break; //Protocol-hello option
+			case 0x09: break; //VTP Management domain
+			case 0x0a: break; //Native VLAN ID
 			{
-			}
-			case 0x08: //Protocol-hello option
-			{
-			}
-			case 0x09: //VTP Management domain
-			{
-			}
-			case 0x0a: //Native VLAN ID
-			{
-				int port_vlan = (packetData[count] << 8 | packetData[count + 1]);
-
-				//printf("VLAN ID: %i", port_vlan);
+				int port_vlan = (value[0] << 8 | value[1]);
 				_itoa_s(port_vlan, Poststring::systemvlan, 10);
 				Poststring::slsystemvlan = strlen(Poststring::systemvlan);
-
 				count += 2;
-
-				printf("%i", port_vlan);
 				break;
 			}
-			case 0x0b: //Duplex
-			{
-			}
-			case 0x0c:
-			{
-			}
-			case 0x0d:
-			{
-			}
-			case 0x0e: //ATA - 186 VoIP VLAN request
-			{
-			}
-			case 0x0f: //ATA-186 VoIP VLAN assignment
-			{
-			}
-			case 0x10: //Power Consumption
-			{
-			}
-			case 0x11: //MTU
-			{
-			}
-			case 0x12: //AVVID Trust bitmap
-			{
-			}
-			case 0x13: //AVVID Untrusted Ports CoS
-			{
-			}
-			case 0x14: //System Name
-			{
-			}
-			case 0x15: //System Object ID?
-			{
-			}
-			case 0x16: //Management Address
-			{
-			}
-			case 0x17: //Location - physical location?
-			{
-			}
-			case 0x18: //Unknown
-			{
-			}
-			case 0x19:
-			{
-			}
-			case 0x1a: //Power available
-			{
-			}
-			case 0x1b:
-			{
-			}
-			case 0x1c:
-			{
-			}
-			case 0x1d: //Energywise
-			{
-			}
-			case 0x1e:
-			{
-			}
-			case 0x1f: //Spare POE
-			{
-			}
+			case 0x0b: break; //Duplex
+			case 0x0c: break;
+			case 0x0d: break;
+			case 0x0e: break; //ATA - 186 VoIP VLAN request
+			case 0x0f: break; //ATA-186 VoIP VLAN assignment
+			case 0x10: break; //Power Consumption
+			case 0x11: break; //MTU
+			case 0x12: break; //AVVID Trust bitmap
+			case 0x13: break; //AVVID Untrusted Ports CoS
+			case 0x14: break; //System Name
+			case 0x15: break; //System Object ID?
+			case 0x16: break; //Management Address
+			case 0x17: break; //Location - physical location?
+			case 0x18: break; //Unknown
+			case 0x19: break;
+			case 0x1a: break; //Power available
+			case 0x1b: break;
+			case 0x1c: break;
+			case 0x1d: break; //Energywise
+			case 0x1e: break;
+			case 0x1f: break; //Spare POE
 			default:
 			{
 				printf("\n\n\t *** Unknown *** value = %s", value);

--- a/LanMap Filter/dissectors.cpp
+++ b/LanMap Filter/dissectors.cpp
@@ -47,7 +47,8 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 	printf("\n\tDestination MAC address:\t %02x:%02x:%02x:%02x:%02x:%02x", packetData[0], packetData[1], packetData[2], packetData[3], packetData[4], packetData[5]);
 	printf("\n\tSource MAC address:\t\t %02x:%02x:%02x:%02x:%02x:%02x", packetData[6], packetData[7], packetData[8], packetData[9], packetData[10], packetData[11]);
 	printf("\n\tLength:\t\t %i", (packetData[12] << 8 | packetData[13]));
-	printf("\n\tCisco Discovery Protcol version %i\n\t TTL:%i", packetData[22], packetData[23]);
+	printf("\n\tCisco Discovery Protcol version %i", packetData[22]);
+	//printf("\n\tTTL:%i", packetData[23]);
 
 	unsigned int count = 26;
 
@@ -60,13 +61,12 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 		//length = length & mask;
 		count += 4;
 		length -= 4;
-
+		
+		printf("\n\t%s", cdp_tlv_type[type].value);
 		switch (type)
 		{
-			case 0x01:
+			case 0x01: //Device ID
 			{
-				printf("\n\n\tDevice ID: ");
-
 				memcpy(&Poststring::systemswName, packetData + count, length);
 				Poststring::slsystemswName = strlen(Poststring::systemswName);
 
@@ -78,11 +78,8 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 				printf("%s", value);//, count - length);
 				break;
 			}
-			case 0x02:
+			case 0x02: //Address
 			{
-				printf("\n\n\tAddress: ");
-
-				//Number of addresses
 				long numberOfAddresses = (packetData[count] << 24 | packetData[count] << 16 | packetData[count + 2] << 8 | packetData[count + 3]);
 				count += 4;
 				length -= 4;
@@ -108,15 +105,11 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 						Poststring::slsystemswIP = strlen(Poststring::systemswIP);
 						count += addressLength;
 					}
-
 				}
-
 				break;
 			}
-			case 0x03:
+			case 0x03: //Port ID
 			{
-				printf("\n\n\tPort-ID: ");
-
 				memcpy(&Poststring::systemswitchport, packetData + count, length);
 				Poststring::slsystemswitchport = strlen(Poststring::systemswitchport);
 
@@ -127,10 +120,8 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 				}
 				break;
 			}
-			case 0x04:
+			case 0x04: //Capabilities
 			{
-				printf("\n\n\tCapability: ");
-
 				for (UINT16 x = 0; x < length; x++)
 				{
 					value[x] = packetData[count];
@@ -139,10 +130,8 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 				printf("%s", value);//, count - length);
 				break;
 			}
-			case 0x05:
+			case 0x05: //Version string, can be quite long
 			{
-				printf("\n\n\tVersion String: ");
-
 				for (UINT16 x = 0; x < length; x++)
 				{
 					value[x] = packetData[count];
@@ -151,10 +140,8 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 				printf("%s", value);//, count - length);
 				break;
 			}
-			case 0x06:
+			case 0x06: //Platform
 			{
-				printf("\n\n\tPlatform: ");
-
 				memcpy(&Poststring::systemswMAC, packetData + count, length);
 				Poststring::slsystemswMAC = strlen(Poststring::systemswMAC);
 				for (UINT16 x = 0; x < length; x++)
@@ -165,10 +152,8 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 				printf("%s", value);//, count - length);
 				break;
 			}
-			case 0x07:
+			case 0x07: //Prefixes
 			{
-				printf("\n\n\tPrefixes: ");
-
 				for (UINT16 x = 0; x < length; x++)
 				{
 					value[x] = packetData[count];
@@ -177,10 +162,8 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 				printf("%s", value);//, count - length);
 				break;
 			}
-			case 0x08:
+			case 0x08: //Protocol-hello option
 			{
-				printf("\n\n\tProtocol-Hello option: ");
-
 				for (UINT16 x = 0; x < length; x++)
 				{
 					value[x] = packetData[count];
@@ -189,10 +172,8 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 				printf("%s", value);//, count - length);
 				break;
 			}
-			case 0x09:
+			case 0x09: //VTP Management domain
 			{
-				printf("\n\n\tVTP Management Domain: ");
-
 				for (UINT16 x = 0; x < length; x++)
 				{
 					value[x] = packetData[count];
@@ -201,10 +182,8 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 				printf("%s", value);//, count - length);
 				break;
 			}
-			case 0x0a:
+			case 0x0a: //Native VLAN ID
 			{
-
-				printf("\n\n\tNative VLAN ID: ");
 				int port_vlan = (packetData[count] << 8 | packetData[count + 1]);
 
 				//printf("VLAN ID: %i", port_vlan);
@@ -216,10 +195,8 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 				printf("%i", port_vlan);
 				break;
 			}
-			case 0x0b:
+			case 0x0b: //Duplex
 			{
-				printf("\n\n\tDuplex: ");
-
 				for (UINT16 x = 0; x < length; x++)
 				{
 					value[x] = packetData[count];
@@ -230,8 +207,6 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 			}
 			case 0x0c:
 			{
-				printf("\n\n\tDONT KNOW LOL");
-
 				for (UINT16 x = 0; x < length; x++)
 				{
 					value[x] = packetData[count];
@@ -242,8 +217,6 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 			}
 			case 0x0d:
 			{
-				printf("\n\n\tDONT KNOW LOL");
-
 				for (UINT16 x = 0; x < length; x++)
 				{
 					value[x] = packetData[count];
@@ -252,10 +225,8 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 				printf("%s", value);//, count - length);
 				break;
 			}
-			case 0x0e:
+			case 0x0e: //ATA - 186 VoIP VLAN request
 			{
-				printf("\n\n\tATA-186 VoIP VLAN request: ");
-
 				for (UINT16 x = 0; x < length; x++)
 				{
 					value[x] = packetData[count];
@@ -264,10 +235,8 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 				printf("%s", value);//, count - length);
 				break;
 			}
-			case 0x0f:
+			case 0x0f: //ATA-186 VoIP VLAN assignment
 			{
-				printf("\n\n\tATA-186 VoIP VLAN assignment: ");
-
 				for (UINT16 x = 0; x < length; x++)
 				{
 					value[x] = packetData[count];
@@ -276,10 +245,8 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 				printf("%s", value);//, count - length);
 				break;
 			}
-			case 0x10:
+			case 0x10: //Power Consumption
 			{
-				printf("\n\n\tPower Consumption: ");
-
 				for (UINT16 x = 0; x < length; x++)
 				{
 					value[x] = packetData[count];
@@ -288,10 +255,8 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 				printf("%s", value);//, count - length);
 				break;
 			}
-			case 0x11:
+			case 0x11: //MTU
 			{
-				printf("\n\n\tMTU: ");
-
 				for (UINT16 x = 0; x < length; x++)
 				{
 					value[x] = packetData[count];
@@ -300,10 +265,8 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 				printf("%s", value);//, count - length);
 				break;
 			}
-			case 0x12:
+			case 0x12: //AVVID Trust bitmap
 			{
-				printf("\n\n\tAVVID Trust Bitmap: ");
-
 				for (UINT16 x = 0; x < length; x++)
 				{
 					value[x] = packetData[count];
@@ -312,10 +275,8 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 				printf("%s", value);//, count - length);
 				break;
 			}
-			case 0x13:
+			case 0x13: //AVVID Untrusted Ports CoS
 			{
-				printf("\n\n\tAVVID Untrusted Ports CoS: ");
-
 				for (UINT16 x = 0; x < length; x++)
 				{
 					value[x] = packetData[count];
@@ -324,10 +285,8 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 				printf("%s", value);//, count - length);
 				break;
 			}
-			case 0x14:
+			case 0x14: //System Name
 			{
-				printf("\n\n\tSystem Name: ");
-
 				for (UINT16 x = 0; x < length; x++)
 				{
 					value[x] = packetData[count];
@@ -336,10 +295,8 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 				printf("%s", value);//, count - length);
 				break;
 			}
-			case 0x15:
+			case 0x15: //System Object ID?
 			{
-				printf("\n\n\tSystem Object ID (Not Decoded): ");
-
 				for (UINT16 x = 0; x < length; x++)
 				{
 					value[x] = packetData[count];
@@ -348,10 +305,8 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 				printf("%s", value);//, count - length);
 				break;
 			}
-			case 0x16:
+			case 0x16: //Management Address
 			{
-				printf("\n\n\tManagement Addresses: ");
-
 				for (UINT16 x = 0; x < length; x++)
 				{
 					value[x] = packetData[count];
@@ -360,10 +315,8 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 				printf("%s", value);//, count - length);
 				break;
 			}
-			case 0x17:
-			{
-				printf("\n\n\tPhysical Location: ");
-
+			case 0x17: //Location - physical location?
+			{	
 				for (UINT16 x = 0; x < length; x++)
 				{
 					value[x] = packetData[count];
@@ -372,10 +325,8 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 				printf("%s", value);//, count - length);
 				break;
 			}
-			case 0x18:
+			case 0x18: //Unknown
 			{
-				printf("\n\n\tUNKNOWN: ");
-
 				for (UINT16 x = 0; x < length; x++)
 				{
 					value[x] = packetData[count];
@@ -386,8 +337,6 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 			}
 			case 0x19:
 			{
-				printf("\n\n\tUNKNOWN: ");
-
 				for (UINT16 x = 0; x < length; x++)
 				{
 					value[x] = packetData[count];
@@ -396,10 +345,8 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 				printf("%s", value);//, count - length);
 				break;
 			}
-			case 0x1a:
+			case 0x1a: //Power available
 			{
-				printf("\n\n\tPower Available: ");
-
 				for (UINT16 x = 0; x < length; x++)
 				{
 					value[x] = packetData[count];
@@ -410,8 +357,6 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 			}
 			case 0x1b:
 			{
-				printf("\n\n\tUNKNOWN: ");
-
 				for (UINT16 x = 0; x < length; x++)
 				{
 					value[x] = packetData[count];
@@ -421,10 +366,7 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 				break;
 			}
 			case 0x1c:
-			{
-				printf("\n\n\tUNKNOWN: ");
-
-				for (UINT16 x = 0; x < length; x++)
+			{for (UINT16 x = 0; x < length; x++)
 				{
 					value[x] = packetData[count];
 					count++;
@@ -432,10 +374,8 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 				printf("%s", value);//, count - length);
 				break;
 			}
-			case 0x1d:
+			case 0x1d: //Energywise
 			{
-				printf("\n\n\tEnergyWise: ");
-
 				for (UINT16 x = 0; x < length; x++)
 				{
 					value[x] = packetData[count];
@@ -446,8 +386,6 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 			}
 			case 0x1e:
 			{
-				printf("\n\n\tUNKNOWN: ");
-
 				for (UINT16 x = 0; x < length; x++)
 				{
 					value[x] = packetData[count];
@@ -456,10 +394,8 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 				printf("%s", value);//, count - length);
 				break;
 			}
-			case 0x1f:
+			case 0x1f: //Spare POE
 			{
-				printf("\n\n\tSpare PoE: ");
-
 				for (UINT16 x = 0; x < length; x++)
 				{
 					value[x] = packetData[count];
@@ -475,6 +411,7 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 			}
 		}
 	}
+	return 0;
 }
 
 int Dissectors::GetDataLLDP(const u_char* packetData, int dataLength)

--- a/LanMap Filter/dissectors.cpp
+++ b/LanMap Filter/dissectors.cpp
@@ -16,8 +16,9 @@ Dissectors::IndexValue Dissectors::lldp_tlv_type[10] =
 	{ LLDP_ORG_SPEC, "Organisation-specific LLDP" },
 };
 
-Dissectors::IndexValue Dissectors::cdp_tlv_type[22] =
+Dissectors::IndexValue Dissectors::cdp_tlv_type[32] =
 {
+	{ 0x00, NULL },
 	{ 0x01, "Device-ID" },
 	{ 0x02, "Address" },
 	{ 0x03, "Port-ID" },
@@ -29,6 +30,8 @@ Dissectors::IndexValue Dissectors::cdp_tlv_type[22] =
 	{ 0x09, "VTP Management Domain" },
 	{ 0x0a, "Native VLAN ID" },
 	{ 0x0b, "Duplex" },
+	{ 0x0c, "Unknown" },
+	{ 0x0d, "Unknown" },
 	{ 0x0e, "ATA-186 VoIP VLAN request" },
 	{ 0x0f, "ATA-186 VoIP VLAN assignment" },
 	{ 0x10, "Power Consumption" },
@@ -39,7 +42,14 @@ Dissectors::IndexValue Dissectors::cdp_tlv_type[22] =
 	{ 0x15, "System Object ID (not decoded)" },
 	{ 0x16, "Management Addresses" },
 	{ 0x17, "Physical Location" },
-	{ 0, NULL }
+	{ 0x18, "Unknown" },
+	{ 0x19, "Power Requested" },
+	{ 0x1a, "Power Available" },
+	{ 0x1b, "Port Unidirectional" },
+	{ 0x1c, "Unknown" },
+	{ 0x1d, "Energywise" },
+	{ 0x1e, "Unknown" },
+	{ 0x1f, "Spare Pair POE" }
 };
 
 int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
@@ -144,12 +154,12 @@ int Dissectors::GetDataCDP(const u_char* packetData, int dataLength)
 			case 0x16: break; //Management Address
 			case 0x17: break; //Location - physical location?
 			case 0x18: break; //Unknown
-			case 0x19: break;
+			case 0x19: break; //Power requested
 			case 0x1a: break; //Power available
-			case 0x1b: break;
-			case 0x1c: break;
+			case 0x1b: break; //Port Unidirectional
+			case 0x1c: break; //Unknown
 			case 0x1d: break; //Energywise
-			case 0x1e: break;
+			case 0x1e: break; //Unknown
 			case 0x1f: break; //Spare POE
 			default:
 			{

--- a/LanMap Filter/dissectors.h
+++ b/LanMap Filter/dissectors.h
@@ -21,5 +21,5 @@ class Dissectors {
 		static int GetDataLLDP(const u_char* packetData, int dataLength);
 
 		static IndexValue lldp_tlv_type[10];
-		static IndexValue cdp_tlv_type[22];
+		static IndexValue cdp_tlv_type[32];
 };

--- a/LanMap Filter/stdafx.h
+++ b/LanMap Filter/stdafx.h
@@ -9,6 +9,8 @@
 #include "dissectors.h"
 #include "Poststring.h"
 
+#define VERSION_STRING "1.01"
+
 #ifdef WIN32
 typedef unsigned char BYTE;
 typedef unsigned char u_char;


### PR DESCRIPTION
Cut down and reformat the CDP dissector. Lots can be got rid of, since all TLVs can be treated in almost the same way and individual TLV code can be scrapped for the most part.